### PR TITLE
Add parentheses when evaluating recursive

### DIFF
--- a/mount-idmapped.c
+++ b/mount-idmapped.c
@@ -679,7 +679,7 @@ int main(int argc, char *argv[])
 				OPEN_TREE_CLONE |
 				OPEN_TREE_CLOEXEC |
 				AT_EMPTY_PATH |
-				recursive ? AT_RECURSIVE : 0);
+				(recursive ? AT_RECURSIVE : 0));
 	if (fd_tree < 0) {
 		exit_log("%m - Failed to open %s\n", source);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Without those `|` is evaluated before `?` calling `sys_open_tree()` with `AT_RECURSIVE` all the times.

Saw this with gcc 9.3.0. 